### PR TITLE
Added tests for utils.py and config.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
-omit = drms/tests/*
+omit = drms/tests/*, drms/_version.py
 

--- a/drms/tests/online/test_jsoc_email.py
+++ b/drms/tests/online/test_jsoc_email.py
@@ -63,6 +63,7 @@ def test_email_cmdopt_init(email):
         c = drms.Client('jsoc', email=email)
         assert c.email == email
 
+
 def test_query_invalid():
     cfg = ServerConfig(name='TEST')
     with pytest.raises(DrmsOperationNotSupported):

--- a/drms/tests/online/test_jsoc_email.py
+++ b/drms/tests/online/test_jsoc_email.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import drms
 
+from drms.error import DrmsQueryError, DrmsExportError, DrmsOperationNotSupported
+from drms.config import ServerConfig
 
 # Invalid email addresses used for testing
 invalid_emails = [
@@ -60,3 +62,8 @@ def test_email_cmdopt_init(email):
     else:
         c = drms.Client('jsoc', email=email)
         assert c.email == email
+
+def test_query_invalid():
+    cfg = ServerConfig(name='TEST')
+    with pytest.raises(DrmsOperationNotSupported):
+        c = drms.Client(server=cfg, email='user@example.com')

--- a/drms/tests/online/test_jsoc_export.py
+++ b/drms/tests/online/test_jsoc_export.py
@@ -31,3 +31,38 @@ def test_export_asis_basic(jsoc_client_export, method):
     for url in r.urls.url:
         assert (url.endswith('mean.fits') or
                 url.endswith('power.fits'))
+
+
+@pytest.mark.jsoc
+@pytest.mark.export
+def test_export_fits_basic(jsoc_client_export):
+    r = jsoc_client_export.export(
+        'hmi.sharp_720s[4864][2014.11.30_00:00_TAI]{continuum, magnetogram}',
+        protocol='fits', method='url', requestor=False)
+
+    assert isinstance(r, drms.ExportRequest)
+    assert r.wait(timeout=60)
+    assert r.has_succeeded()
+    assert r.protocol == 'fits'
+    assert len(r.urls) == 2    # 1 file per segment
+
+    for record in r.urls.record:
+        record = record.lower()
+        assert record.startswith('hmi.sharp_720s[4864]')
+        assert record.endswith('2014.11.30_00:00:00_tai]')
+
+    for filename in r.urls.filename:
+        assert (filename.endswith('continuum.fits') or
+                filename.endswith('magnetogram.fits'))
+
+    for url in r.urls.url:
+        assert (url.endswith('continuum.fits') or
+                url.endswith('magnetogram.fits'))
+
+
+@pytest.mark.jsoc
+@pytest.mark.export
+def test_export_email(jsoc_client):
+    with pytest.raises(ValueError):
+        keys = jsoc_client.export(
+            'hmi.v_45s[2016.04.01_TAI/1d@6h]{Dopplergram}')

--- a/drms/tests/online/test_jsoc_info.py
+++ b/drms/tests/online/test_jsoc_info.py
@@ -18,3 +18,21 @@ def test_series_info_basic(jsoc_client, series, pkeys, segments):
         assert k in si.keywords.index
     for s in segments:
         assert s in si.segments.index
+
+@pytest.mark.jsoc
+@pytest.mark.parametrize('series, pkeys', [
+    ('hmi.v_45s', ['T_REC', 'CAMERA']),
+    ('hmi.m_720s', ['T_REC', 'CAMERA']),
+    ('hmi.v_avg120', ['CarrRot', 'CMLon']),
+    ('aia.lev1', ['T_REC', 'FSN']),
+    ('aia.lev1_euv_12s', ['T_REC', 'WAVELNTH']),
+    ('aia.response', ['T_START', 'WAVE_STR']),
+    ('iris.lev1', ['T_OBS', 'FSN']),
+    ('mdi.fd_m_lev182', ['T_REC'])
+    ])
+def test_series_primekeys(jsoc_client,series, pkeys):
+    pkey_list = jsoc_client.pkeys(series)
+    key_list = jsoc_client.keys(series)
+    for k in pkeys:
+        assert k in pkey_list
+        assert k in key_list

--- a/drms/tests/online/test_jsoc_info.py
+++ b/drms/tests/online/test_jsoc_info.py
@@ -19,6 +19,7 @@ def test_series_info_basic(jsoc_client, series, pkeys, segments):
     for s in segments:
         assert s in si.segments.index
 
+
 @pytest.mark.jsoc
 @pytest.mark.parametrize('series, pkeys', [
     ('hmi.v_45s', ['T_REC', 'CAMERA']),
@@ -30,7 +31,7 @@ def test_series_info_basic(jsoc_client, series, pkeys, segments):
     ('iris.lev1', ['T_OBS', 'FSN']),
     ('mdi.fd_m_lev182', ['T_REC'])
     ])
-def test_series_primekeys(jsoc_client,series, pkeys):
+def test_series_primekeys(jsoc_client, series, pkeys):
     pkey_list = jsoc_client.pkeys(series)
     key_list = jsoc_client.keys(series)
     for k in pkeys:

--- a/drms/tests/online/test_jsoc_query.py
+++ b/drms/tests/online/test_jsoc_query.py
@@ -6,6 +6,7 @@ import drms
 from drms.error import DrmsQueryError, DrmsExportError, DrmsOperationNotSupported
 from drms.config import ServerConfig
 
+
 @pytest.mark.jsoc
 def test_query_seg_key(jsoc_client):
     keys, segs = jsoc_client.query(
@@ -18,10 +19,12 @@ def test_query_seg_key(jsoc_client):
     assert 'Dopplergram' in segs.columns
     assert ((keys.CRLT_OBS - 3.14159).abs() < 0.0001).all()
 
+
 @pytest.mark.jsoc
 def test_query_allmissing(jsoc_client):
     with pytest.raises(ValueError):
         keys = jsoc_client.query('hmi.v_45s[2013.07.03_08:42_TAI/3m]')
+
 
 @pytest.mark.jsoc
 def test_query_key(jsoc_client):
@@ -33,13 +36,15 @@ def test_query_key(jsoc_client):
         assert k in keys.columns
     assert ((keys.CRLT_OBS - 3.14159).abs() < 0.0001).all()
 
+
 @pytest.mark.jsoc
 def test_query_seg(jsoc_client):
     segs = jsoc_client.query(
         'hmi.v_45s[2013.07.03_08:42_TAI/3m]',
-         seg='Dopplergram')
+        seg='Dopplergram')
     assert len(segs) == 4
     assert 'Dopplergram' in segs.columns
+
 
 @pytest.mark.jsoc
 def test_query_link(jsoc_client):
@@ -49,17 +54,19 @@ def test_query_link(jsoc_client):
     assert len(links) == 3
     assert 'MDATA' in links.columns
 
+
 @pytest.mark.jsoc
 def test_query_seg_key_link(jsoc_client):
     keys, segs, links = jsoc_client.query(
         'hmi.B_720s[2013.07.03_08:42_TAI/40m]',
-        key='foo', link = 'bar', seg='baz')
+        key='foo', link='bar', seg='baz')
     assert len(keys) == 3
     assert (keys.foo == 'Invalid KeyLink').all()
     assert len(segs) == 3
     assert (segs.baz == 'InvalidSegName').all()
     assert len(links) == 3
     assert (links.bar == 'Invalid_Link').all()
+
 
 @pytest.mark.jsoc
 def test_query_pkeys(jsoc_client):
@@ -70,14 +77,16 @@ def test_query_pkeys(jsoc_client):
     assert pkeys == jsoc_client.pkeys('hmi.v_45s[2013.07.03_08:42_TAI/3m]')
     assert len(keys) == 4
 
+
 @pytest.mark.jsoc
 def test_query_recindex(jsoc_client):
     keys = jsoc_client.query(
         'hmi.V_45s[2013.07.03_08:42_TAI/4m]',
-        key = 'T_REC', rec_index=True)
+        key='T_REC', rec_index=True)
     index_values = list(keys.index.values)
     assert all(['hmi.V_45s' in s for s in index_values])
     assert len(keys) == 5
+
 
 def test_query_invalid_server():
     cfg = ServerConfig(name='TEST')
@@ -87,7 +96,8 @@ def test_query_invalid_server():
             'hmi.v_45s[2013.07.03_08:42_TAI/3m]',
             pkeys=True)
 
+
 @pytest.mark.jsoc
 def test_query_invalid_series(jsoc_client):
     with pytest.raises(DrmsQueryError):
-        keys = jsoc_client.query('foo', key = 'T_REC')
+        keys = jsoc_client.query('foo', key='T_REC')

--- a/drms/tests/online/test_jsoc_query.py
+++ b/drms/tests/online/test_jsoc_query.py
@@ -3,9 +3,11 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import drms
 
+from drms.error import DrmsQueryError, DrmsExportError, DrmsOperationNotSupported
+from drms.config import ServerConfig
 
 @pytest.mark.jsoc
-def test_query_basic(jsoc_client):
+def test_query_seg_key(jsoc_client):
     keys, segs = jsoc_client.query(
         'hmi.v_45s[2013.07.03_08:42_TAI/3m]',
         key='T_REC, CRLT_OBS', seg='Dopplergram')
@@ -15,3 +17,77 @@ def test_query_basic(jsoc_client):
     assert len(segs) == 4
     assert 'Dopplergram' in segs.columns
     assert ((keys.CRLT_OBS - 3.14159).abs() < 0.0001).all()
+
+@pytest.mark.jsoc
+def test_query_allmissing(jsoc_client):
+    with pytest.raises(ValueError):
+        keys = jsoc_client.query('hmi.v_45s[2013.07.03_08:42_TAI/3m]')
+
+@pytest.mark.jsoc
+def test_query_key(jsoc_client):
+    keys = jsoc_client.query(
+        'hmi.v_45s[2013.07.03_08:42_TAI/3m]',
+        key='T_REC, CRLT_OBS')
+    assert len(keys) == 4
+    for k in ['T_REC', 'CRLT_OBS']:
+        assert k in keys.columns
+    assert ((keys.CRLT_OBS - 3.14159).abs() < 0.0001).all()
+
+@pytest.mark.jsoc
+def test_query_seg(jsoc_client):
+    segs = jsoc_client.query(
+        'hmi.v_45s[2013.07.03_08:42_TAI/3m]',
+         seg='Dopplergram')
+    assert len(segs) == 4
+    assert 'Dopplergram' in segs.columns
+
+@pytest.mark.jsoc
+def test_query_link(jsoc_client):
+    links = jsoc_client.query(
+        'hmi.B_720s[2013.07.03_08:42_TAI/40m]',
+        link='MDATA')
+    assert len(links) == 3
+    assert 'MDATA' in links.columns
+
+@pytest.mark.jsoc
+def test_query_seg_key_link(jsoc_client):
+    keys, segs, links = jsoc_client.query(
+        'hmi.B_720s[2013.07.03_08:42_TAI/40m]',
+        key='foo', link = 'bar', seg='baz')
+    assert len(keys) == 3
+    assert (keys.foo == 'Invalid KeyLink').all()
+    assert len(segs) == 3
+    assert (segs.baz == 'InvalidSegName').all()
+    assert len(links) == 3
+    assert (links.bar == 'Invalid_Link').all()
+
+@pytest.mark.jsoc
+def test_query_pkeys(jsoc_client):
+    keys = jsoc_client.query(
+        'hmi.v_45s[2013.07.03_08:42_TAI/3m]',
+        pkeys=True)
+    pkeys = list(keys.columns.values)
+    assert pkeys == jsoc_client.pkeys('hmi.v_45s[2013.07.03_08:42_TAI/3m]')
+    assert len(keys) == 4
+
+@pytest.mark.jsoc
+def test_query_recindex(jsoc_client):
+    keys = jsoc_client.query(
+        'hmi.V_45s[2013.07.03_08:42_TAI/4m]',
+        key = 'T_REC', rec_index=True)
+    index_values = list(keys.index.values)
+    assert all(['hmi.V_45s' in s for s in index_values])
+    assert len(keys) == 5
+
+def test_query_invalid_server():
+    cfg = ServerConfig(name='TEST')
+    c = drms.Client(server=cfg)
+    with pytest.raises(DrmsOperationNotSupported):
+        keys = c.query(
+            'hmi.v_45s[2013.07.03_08:42_TAI/3m]',
+            pkeys=True)
+
+@pytest.mark.jsoc
+def test_query_invalid_series(jsoc_client):
+    with pytest.raises(DrmsQueryError):
+        keys = jsoc_client.query('foo', key = 'T_REC')

--- a/drms/tests/test_client.py
+++ b/drms/tests/test_client.py
@@ -3,6 +3,10 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import drms
 from drms.config import ServerConfig
+from drms import SeriesInfo
+
+import pandas as pd
+from collections import OrderedDict
 
 
 def test_client_init_defaults():
@@ -43,3 +47,89 @@ def test_client_custom_config():
     c = drms.Client(server=cfg)
     assert isinstance(c._server, ServerConfig)
     assert c._server.name == 'TEST'
+
+
+class Test_SeriesInfo(object):
+
+    def test_parse_keywords(self):
+        info = [{'recscope': 'variable', 'units': 'none', 'name': 'cparms_sg000',
+                'defval': 'compress Rice', 'note': '', 'type': 'string'},
+                {'recscope': 'variable', 'units': 'none', 'name': 'mean_bzero',
+                'defval': '0', 'note': '', 'type': 'double'},
+                {'recscope': 'variable', 'units': 'none', 'name': 'mean_bscale',
+                'defval': '0.25', 'note': '', 'type': 'double'},
+                {'recscope': 'variable', 'units': 'TAI', 'name': 'MidTime',
+                 'defval': '-4712.01.01_11:59_TAI',
+                 'note': 'Midpoint of averaging interval',
+                 'type': 'time'}]
+        exp = OrderedDict([('name', ['cparms_sg000', 'mean_bzero',
+                                     'mean_bscale', 'MidTime']),
+                           ('type', ['string', 'double', 'double', 'time']),
+                           ('recscope', ['variable', 'variable',
+                                         'variable', 'variable']),
+                           ('defval', ['compress Rice', '0', '0.25',
+                                       '-4712.01.01_11:59_TAI']),
+                           ('units', ['none', 'none', 'none', 'TAI']),
+                           ('note', ['', '', '', 'Midpoint of averaging interval']),
+                           ('linkinfo', [None, None, None, None]),
+                           ('is_time', [False, False, False, True]),
+                           ('is_integer', [False, False, False, False]),
+                           ('is_real', [False, True, True, False]),
+                           ('is_numeric', [False, True, True, False])
+                           ])
+
+        exp = pd.DataFrame(data=exp)
+        exp.index = exp.pop('name')
+        assert SeriesInfo._parse_keywords(info).equals(exp)
+
+    def test_parse_links(self):
+        links = [{'name': 'BHARP', 'kind': 'DYNAMIC', 'note': 'Bharp',
+                  'target': 'hmi.Bharp_720s'},
+                 {'name': 'MHARP', 'kind': 'DYNAMIC', 'note': 'Mharp',
+                  'target': 'hmi.Mharp_720s'}]
+        exp = OrderedDict([('name', ['BHARP', 'MHARP']),
+                           ('target', ['hmi.Bharp_720s', 'hmi.Mharp_720s']),
+                           ('kind', ['DYNAMIC', 'DYNAMIC']),
+                           ('note', ['Bharp', 'Mharp'])
+                           ])
+        exp = pd.DataFrame(data=exp)
+        exp.index = exp.pop('name')
+        assert SeriesInfo._parse_links(links).equals(exp)
+
+    def test_parse_segments(self):
+        segments = [{'type': 'int', 'dims': 'VARxVAR',
+                     'units': 'Gauss', 'protocol': 'fits',
+                     'note': 'magnetogram', 'name': 'magnetogram'},
+                    {'type': 'char', 'dims': 'VARxVAR',
+                     'units': 'Enumerated', 'protocol': 'fits',
+                     'note': 'Mask for the patch', 'name': 'bitmap'},
+                    {'type': 'int', 'dims': 'VARxVAR',
+                     'units': 'm/s', 'protocol': 'fits',
+                     'note': 'Dopplergram', 'name': 'Dopplergram'}]
+        exp = OrderedDict([('name', ['magnetogram', 'bitmap', 'Dopplergram']),
+                           ('type', ['int', 'char', 'int']),
+                           ('units', ['Gauss', 'Enumerated', 'm/s']),
+                           ('protocol', ['fits', 'fits', 'fits']),
+                           ('dims', ['VARxVAR', 'VARxVAR', 'VARxVAR']),
+                           ('note', ['magnetogram', 'Mask for the patch',
+                                     'Dopplergram'])
+                           ])
+
+        exp = pd.DataFrame(data=exp)
+        exp.index = exp.pop('name')
+        assert SeriesInfo._parse_segments(segments).equals(exp)
+
+    def test_repr(self):
+        info = {'primekeys': ['CarrRot', 'CMLon'],
+                'retention': 1800,
+                'tapegroup': 1,
+                'archive': 1,
+                'primekeysinfo': [],
+                'unitsize': 1,
+                'note': 'Temporal averages of HMI Vgrams over 1/3 CR',
+                'dbindex': [None],
+                'links': [],
+                'segments': [],
+                'keywords': []}
+        assert repr(SeriesInfo(info)) == '<SeriesInfo>'
+        assert repr(SeriesInfo(info, 'hmi')) == '<SeriesInfo "hmi">'

--- a/drms/tests/test_client.py
+++ b/drms/tests/test_client.py
@@ -51,6 +51,3 @@ def test_client_custom_config():
 def test_repr():
     assert repr(drms.Client()) == '<Client "JSOC">'
     assert repr(drms.Client(server='kis')) == '<Client "KIS">'
-
-def test_convert_numeric_keywords():
-    pass

--- a/drms/tests/test_client.py
+++ b/drms/tests/test_client.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import drms
 from drms.config import ServerConfig
-from drms import SeriesInfo
 
 import pandas as pd
 from collections import OrderedDict
@@ -49,87 +48,9 @@ def test_client_custom_config():
     assert c._server.name == 'TEST'
 
 
-class Test_SeriesInfo(object):
+def test_repr(self):
+    assert repr(drms.Client()) == '<Client "JSOC">'
+    assert repr(drms.Client(server='kis')) == '<Client "KIS">'
 
-    def test_parse_keywords(self):
-        info = [{'recscope': 'variable', 'units': 'none', 'name': 'cparms_sg000',
-                'defval': 'compress Rice', 'note': '', 'type': 'string'},
-                {'recscope': 'variable', 'units': 'none', 'name': 'mean_bzero',
-                'defval': '0', 'note': '', 'type': 'double'},
-                {'recscope': 'variable', 'units': 'none', 'name': 'mean_bscale',
-                'defval': '0.25', 'note': '', 'type': 'double'},
-                {'recscope': 'variable', 'units': 'TAI', 'name': 'MidTime',
-                 'defval': '-4712.01.01_11:59_TAI',
-                 'note': 'Midpoint of averaging interval',
-                 'type': 'time'}]
-        exp = OrderedDict([('name', ['cparms_sg000', 'mean_bzero',
-                                     'mean_bscale', 'MidTime']),
-                           ('type', ['string', 'double', 'double', 'time']),
-                           ('recscope', ['variable', 'variable',
-                                         'variable', 'variable']),
-                           ('defval', ['compress Rice', '0', '0.25',
-                                       '-4712.01.01_11:59_TAI']),
-                           ('units', ['none', 'none', 'none', 'TAI']),
-                           ('note', ['', '', '', 'Midpoint of averaging interval']),
-                           ('linkinfo', [None, None, None, None]),
-                           ('is_time', [False, False, False, True]),
-                           ('is_integer', [False, False, False, False]),
-                           ('is_real', [False, True, True, False]),
-                           ('is_numeric', [False, True, True, False])
-                           ])
-
-        exp = pd.DataFrame(data=exp)
-        exp.index = exp.pop('name')
-        assert SeriesInfo._parse_keywords(info).equals(exp)
-
-    def test_parse_links(self):
-        links = [{'name': 'BHARP', 'kind': 'DYNAMIC', 'note': 'Bharp',
-                  'target': 'hmi.Bharp_720s'},
-                 {'name': 'MHARP', 'kind': 'DYNAMIC', 'note': 'Mharp',
-                  'target': 'hmi.Mharp_720s'}]
-        exp = OrderedDict([('name', ['BHARP', 'MHARP']),
-                           ('target', ['hmi.Bharp_720s', 'hmi.Mharp_720s']),
-                           ('kind', ['DYNAMIC', 'DYNAMIC']),
-                           ('note', ['Bharp', 'Mharp'])
-                           ])
-        exp = pd.DataFrame(data=exp)
-        exp.index = exp.pop('name')
-        assert SeriesInfo._parse_links(links).equals(exp)
-
-    def test_parse_segments(self):
-        segments = [{'type': 'int', 'dims': 'VARxVAR',
-                     'units': 'Gauss', 'protocol': 'fits',
-                     'note': 'magnetogram', 'name': 'magnetogram'},
-                    {'type': 'char', 'dims': 'VARxVAR',
-                     'units': 'Enumerated', 'protocol': 'fits',
-                     'note': 'Mask for the patch', 'name': 'bitmap'},
-                    {'type': 'int', 'dims': 'VARxVAR',
-                     'units': 'm/s', 'protocol': 'fits',
-                     'note': 'Dopplergram', 'name': 'Dopplergram'}]
-        exp = OrderedDict([('name', ['magnetogram', 'bitmap', 'Dopplergram']),
-                           ('type', ['int', 'char', 'int']),
-                           ('units', ['Gauss', 'Enumerated', 'm/s']),
-                           ('protocol', ['fits', 'fits', 'fits']),
-                           ('dims', ['VARxVAR', 'VARxVAR', 'VARxVAR']),
-                           ('note', ['magnetogram', 'Mask for the patch',
-                                     'Dopplergram'])
-                           ])
-
-        exp = pd.DataFrame(data=exp)
-        exp.index = exp.pop('name')
-        assert SeriesInfo._parse_segments(segments).equals(exp)
-
-    def test_repr(self):
-        info = {'primekeys': ['CarrRot', 'CMLon'],
-                'retention': 1800,
-                'tapegroup': 1,
-                'archive': 1,
-                'primekeysinfo': [],
-                'unitsize': 1,
-                'note': 'Temporal averages of HMI Vgrams over 1/3 CR',
-                'dbindex': [None],
-                'links': [],
-                'segments': [],
-                'keywords': []}
-        assert repr(SeriesInfo(info)) == '<SeriesInfo>'
-        assert repr(SeriesInfo(info, 'hmi')) == '<SeriesInfo "hmi">'
+def test_convert_numeric_keywords(self):
+    pass

--- a/drms/tests/test_client.py
+++ b/drms/tests/test_client.py
@@ -48,9 +48,9 @@ def test_client_custom_config():
     assert c._server.name == 'TEST'
 
 
-def test_repr(self):
+def test_repr():
     assert repr(drms.Client()) == '<Client "JSOC">'
     assert repr(drms.Client(server='kis')) == '<Client "KIS">'
 
-def test_convert_numeric_keywords(self):
+def test_convert_numeric_keywords():
     pass

--- a/drms/tests/test_config.py
+++ b/drms/tests/test_config.py
@@ -19,11 +19,48 @@ def test_create_config_basic():
             assert v == 'latin1'
         else:
             assert v is None
+    assert repr(cfg) == '<ServerConfig "TEST">'
 
 
 def test_create_config_missing_name():
     with pytest.raises(ValueError):
         cfg = ServerConfig()
+
+
+def test_create_config_invalid_key():
+    with pytest.raises(ValueError):
+        cfg = ServerConfig(foo='bar')
+
+
+def test_getset_attr():
+    cfg = ServerConfig(name='TEST')
+    assert getattr(cfg, 'name') == 'TEST'
+    assert getattr(cfg, '__dict__') == {'_d': {'encoding': 'latin1', 'name': 'TEST'}}
+    with pytest.raises(AttributeError):
+        getattr(cfg, 'foo')
+    setattr(cfg, 'name', 'NewTest')
+    assert getattr(cfg, 'name') == 'NewTest'
+    with pytest.raises(ValueError):
+        setattr(cfg, 'name', 123)
+    setattr(cfg, '__sizeof__', 127)
+    assert getattr(cfg, '__sizeof__') == 127
+
+
+def test_to_dict():
+    cfg = ServerConfig(name='TEST')
+    _dict = cfg.to_dict()
+    assert isinstance(_dict, dict)
+    assert _dict == {'encoding': 'latin1', 'name': 'TEST'}
+
+
+def test_inbuilt_dir():
+    cfg = ServerConfig(name='TEST')
+    valid_keys = ServerConfig._valid_keys
+    list_attr = dir(cfg)
+    assert isinstance(list_attr, list)
+    assert set(dir(object)).issubset(set(list_attr))
+    assert set(valid_keys).issubset(set(list_attr))
+    assert set(list(cfg.__dict__.keys())).issubset(set(list_attr))
 
 
 def test_copy_config():

--- a/drms/tests/test_seriesinfo.py
+++ b/drms/tests/test_seriesinfo.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+import drms
+from drms.config import ServerConfig
+
+import pandas as pd
+from collections import OrderedDict
+
+
+class Test_SeriesInfo(object):
+
+    def test_parse_keywords(self):
+        info = [{'recscope': 'variable', 'units': 'none', 'name': 'cparms_sg000',
+                'defval': 'compress Rice', 'note': '', 'type': 'string'},
+                {'recscope': 'variable', 'units': 'none', 'name': 'mean_bzero',
+                'defval': '0', 'note': '', 'type': 'double'},
+                {'recscope': 'variable', 'units': 'none', 'name': 'mean_bscale',
+                'defval': '0.25', 'note': '', 'type': 'double'},
+                {'recscope': 'variable', 'units': 'TAI', 'name': 'MidTime',
+                 'defval': '-4712.01.01_11:59_TAI',
+                 'note': 'Midpoint of averaging interval',
+                 'type': 'time'}]
+        exp = OrderedDict([('name', ['cparms_sg000', 'mean_bzero',
+                                     'mean_bscale', 'MidTime']),
+                           ('type', ['string', 'double', 'double', 'time']),
+                           ('recscope', ['variable', 'variable',
+                                         'variable', 'variable']),
+                           ('defval', ['compress Rice', '0', '0.25',
+                                       '-4712.01.01_11:59_TAI']),
+                           ('units', ['none', 'none', 'none', 'TAI']),
+                           ('note', ['', '', '', 'Midpoint of averaging interval']),
+                           ('linkinfo', [None, None, None, None]),
+                           ('is_time', [False, False, False, True]),
+                           ('is_integer', [False, False, False, False]),
+                           ('is_real', [False, True, True, False]),
+                           ('is_numeric', [False, True, True, False])
+                           ])
+
+        exp = pd.DataFrame(data=exp)
+        exp.index = exp.pop('name')
+        assert drms.SeriesInfo._parse_keywords(info).equals(exp)
+
+    def test_parse_links(self):
+        links = [{'name': 'BHARP', 'kind': 'DYNAMIC', 'note': 'Bharp',
+                  'target': 'hmi.Bharp_720s'},
+                 {'name': 'MHARP', 'kind': 'DYNAMIC', 'note': 'Mharp',
+                  'target': 'hmi.Mharp_720s'}]
+        exp = OrderedDict([('name', ['BHARP', 'MHARP']),
+                           ('target', ['hmi.Bharp_720s', 'hmi.Mharp_720s']),
+                           ('kind', ['DYNAMIC', 'DYNAMIC']),
+                           ('note', ['Bharp', 'Mharp'])
+                           ])
+        exp = pd.DataFrame(data=exp)
+        exp.index = exp.pop('name')
+        assert drms.SeriesInfo._parse_links(links).equals(exp)
+
+    def test_parse_segments(self):
+        segments = [{'type': 'int', 'dims': 'VARxVAR',
+                     'units': 'Gauss', 'protocol': 'fits',
+                     'note': 'magnetogram', 'name': 'magnetogram'},
+                    {'type': 'char', 'dims': 'VARxVAR',
+                     'units': 'Enumerated', 'protocol': 'fits',
+                     'note': 'Mask for the patch', 'name': 'bitmap'},
+                    {'type': 'int', 'dims': 'VARxVAR',
+                     'units': 'm/s', 'protocol': 'fits',
+                     'note': 'Dopplergram', 'name': 'Dopplergram'}]
+        exp = OrderedDict([('name', ['magnetogram', 'bitmap', 'Dopplergram']),
+                           ('type', ['int', 'char', 'int']),
+                           ('units', ['Gauss', 'Enumerated', 'm/s']),
+                           ('protocol', ['fits', 'fits', 'fits']),
+                           ('dims', ['VARxVAR', 'VARxVAR', 'VARxVAR']),
+                           ('note', ['magnetogram', 'Mask for the patch',
+                                     'Dopplergram'])
+                           ])
+
+        exp = pd.DataFrame(data=exp)
+        exp.index = exp.pop('name')
+        assert drms.SeriesInfo._parse_segments(segments).equals(exp)
+
+    def test_repr(self):
+        info = {'primekeys': ['CarrRot', 'CMLon'],
+                'retention': 1800,
+                'tapegroup': 1,
+                'archive': 1,
+                'primekeysinfo': [],
+                'unitsize': 1,
+                'note': 'Temporal averages of HMI Vgrams over 1/3 CR',
+                'dbindex': [None],
+                'links': [],
+                'segments': [],
+                'keywords': []}
+        assert repr(drms.SeriesInfo(info)) == '<SeriesInfo>'
+        assert repr(drms.SeriesInfo(info, 'hmi')) == '<SeriesInfo "hmi">'

--- a/drms/tests/test_to_datetime.py
+++ b/drms/tests/test_to_datetime.py
@@ -1,3 +1,4 @@
+
 from __future__ import absolute_import, division, print_function
 
 import pytest
@@ -62,9 +63,36 @@ def test_force_string(time_string, expected):
     (data_tai_in, data_tai_out),
     (pd.Series(data_tai_in), data_tai_out),
     (tuple(data_tai_in), data_tai_out),
-    (np.array(data_tai_in), np.array(data_tai_out)),
-    (dict(zip(tuple(range(len(data_tai_in))), tuple(data_tai_in))),
-     dict(zip(tuple(range(len(data_tai_out))), tuple(data_tai_out))))
+    (np.array(data_tai_in), data_tai_out),
     ])
 def test_time_series(time_series, expected):
-    drms.to_datetime(time_series).equals(expected)
+    assert drms.to_datetime(time_series).equals(expected)
+
+
+data_invalid = [
+    ('2010.05.01_TAI', False),
+    ('2010.05.01_00:00_TAI', False),
+    ('', True),
+    ('1600', True),
+    ('foo', True),
+    ('2013.12.21_23:32:34_TAI', False)
+    ]
+data_invalid_in = [data[0] for data in data_invalid]
+data_invalid_out = pd.Series([data[1] for data in data_invalid])
+
+
+@pytest.mark.parametrize('time_string, expected', data_invalid)
+def test_corner_case(time_string, expected):
+    assert pd.isnull(drms.to_datetime(time_string)) == expected
+    assert isinstance(drms.to_datetime([]), pd.Series)
+    assert drms.to_datetime([]).empty
+
+
+@pytest.mark.parametrize('time_series, expected', [
+    (data_invalid_in, data_invalid_out),
+    (pd.Series(data_invalid_in), data_invalid_out),
+    (tuple(data_invalid_in), data_invalid_out),
+    (np.array(data_invalid_in), data_invalid_out),
+    ])
+def test_corner_case_series(time_series, expected):
+    assert pd.isnull(drms.to_datetime(time_series)).equals(expected)

--- a/drms/tests/test_to_datetime.py
+++ b/drms/tests/test_to_datetime.py
@@ -6,14 +6,19 @@ import numpy as np
 import drms
 
 
-@pytest.mark.parametrize('time_string, expected', [
+data_tai = [
     ('2010.05.01_TAI', pd.Timestamp('2010-05-01 00:00:00')),
     ('2010.05.01_00:00_TAI', pd.Timestamp('2010-05-01 00:00:00')),
     ('2010.05.01_00:00:00_TAI', pd.Timestamp('2010-05-01 00:00:00')),
     ('2010.05.01_01:23:45_TAI', pd.Timestamp('2010-05-01 01:23:45')),
     ('2013.12.21_23:32_TAI', pd.Timestamp('2013-12-21 23:32:00')),
     ('2013.12.21_23:32:34_TAI', pd.Timestamp('2013-12-21 23:32:34')),
-    ])
+    ]
+data_tai_in = [data[0] for data in data_tai]
+data_tai_out = pd.Series([data[1] for data in data_tai])
+
+
+@pytest.mark.parametrize('time_string, expected', data_tai)
 def test_tai_string(time_string, expected):
     assert drms.to_datetime(time_string) == expected
 
@@ -54,16 +59,12 @@ def test_force_string(time_string, expected):
 
 
 @pytest.mark.parametrize('time_series, expected', [
-    (pd.Series(['2010.05.01_00:00_TAI', '2013.12.21_23:32:34_TAI']),
-     pd.Series([pd.Timestamp('2010-05-01 00:00:00'), pd.Timestamp('2013-12-21 23:32:34')])),
-    (['2010.05.01_00:00_TAI', '2013.12.21_23:32:34_TAI'],
-     [pd.Timestamp('2010-05-01 00:00:00'), pd.Timestamp('2013-12-21 23:32:34')]),
-    (('2010.05.01_00:00_TAI', '2013.12.21_23:32:34_TAI'),
-     (pd.Timestamp('2010-05-01 00:00:00'), pd.Timestamp('2013-12-21 23:32:34'))),
-    ({'a': '2010.05.01_00:00_TAI', 'b': '2013.12.21_23:32:34_TAI'},
-     {'a': pd.Timestamp('2010-05-01 00:00:00'), 'b': pd.Timestamp('2013-12-21 23:32:34')}),
-    (np.array(['2010.05.01_00:00_TAI', '2013.12.21_23:32:34_TAI']),
-     np.array([pd.Timestamp('2010-05-01 00:00:00'), pd.Timestamp('2013-12-21 23:32:34')]))
+    (data_tai_in, data_tai_out),
+    (pd.Series(data_tai_in), data_tai_out),
+    (tuple(data_tai_in), data_tai_out),
+    (np.array(data_tai_in), np.array(data_tai_out)),
+    (dict(zip(tuple(range(len(data_tai_in))), tuple(data_tai_in))),
+     dict(zip(tuple(range(len(data_tai_out))), tuple(data_tai_out))))
     ])
 def test_time_series(time_series, expected):
     drms.to_datetime(time_series).equals(expected)

--- a/drms/tests/test_to_datetime.py
+++ b/drms/tests/test_to_datetime.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 import pandas as pd
+import numpy as np
 import drms
 
 
@@ -52,6 +53,17 @@ def test_force_string(time_string, expected):
     assert drms.to_datetime(time_string, force=True) == expected
 
 
-# test_xx_list
-# test_xx_ndarray
-# test_xx_pandas_series
+@pytest.mark.parametrize('time_series, expected', [
+    (pd.Series(['2010.05.01_00:00_TAI', '2013.12.21_23:32:34_TAI']),
+     pd.Series([pd.Timestamp('2010-05-01 00:00:00'), pd.Timestamp('2013-12-21 23:32:34')])),
+    (['2010.05.01_00:00_TAI', '2013.12.21_23:32:34_TAI'],
+     [pd.Timestamp('2010-05-01 00:00:00'), pd.Timestamp('2013-12-21 23:32:34')]),
+    (('2010.05.01_00:00_TAI', '2013.12.21_23:32:34_TAI'),
+     (pd.Timestamp('2010-05-01 00:00:00'), pd.Timestamp('2013-12-21 23:32:34'))),
+    ({'a': '2010.05.01_00:00_TAI', 'b': '2013.12.21_23:32:34_TAI'},
+     {'a': pd.Timestamp('2010-05-01 00:00:00'), 'b': pd.Timestamp('2013-12-21 23:32:34')}),
+    (np.array(['2010.05.01_00:00_TAI', '2013.12.21_23:32:34_TAI']),
+     np.array([pd.Timestamp('2010-05-01 00:00:00'), pd.Timestamp('2013-12-21 23:32:34')]))
+    ])
+def test_time_series(time_series, expected):
+    drms.to_datetime(time_series).equals(expected)

--- a/drms/tests/test_utils.py
+++ b/drms/tests/test_utils.py
@@ -1,13 +1,28 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+import pandas as pd
+
 from drms.utils import (
     _pd_to_datetime_coerce, _pd_to_numeric_coerce,
     _split_arg, _extract_series_name)
 
 
-# test_pd_to_datetime
-# test_pd_to_numeric
+@pytest.mark.parametrize('arg, exp', [
+    (pd.Series(['1.0', '2', -3]), pd.Series([1.0, 2.0, -3.0])),
+    (pd.Series(['1.0', 'apple', -3]), pd.Series([1.0, float('nan'), -3.0]))
+    ])
+def test_pd_to_numeric_coerce(arg, exp):
+    assert _pd_to_numeric_coerce(arg).equals(exp)
+
+
+@pytest.mark.parametrize('arg, exp', [
+    (pd.Series(['2016-04-01 00:00:00', '2016-04-01 06:00:00']),
+     pd.Series([pd.Timestamp('2016-04-01 00:00:00'),
+                pd.Timestamp('2016-04-01 06:00:00')]))
+    ])
+def test_pd_to_datetime_coerce(arg, exp):
+    assert _pd_to_datetime_coerce(arg).equals(exp)
 
 
 @pytest.mark.parametrize('in_obj, expected', [


### PR DESCRIPTION
This PR adds tests for **utils.py**, **config.py** and **client.py**
- [x] Covers config.py to 100%
- [x] Covers utils.py to 81%

WIP for client.py:
- [x] SeriesInfo covered
- [ ] Present coverage of client.py : 26%

TODO:
- [ ] Find a way to write tests for older pandas version in utils.py 
