### PR TITLE
Fix broken documentation links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 drms
 ====
 
-`Docs <https://docs.sunpy.org/projects/drms>`_ |
+`Docs <https://docs.sunpy.org/projects/drms/>`_ |
 `Tutorial <https://docs.sunpy.org/projects/drms/en/latest/tutorial.html>`_ |
 `Github <https://github.com/sunpy/drms>`_ |
 `PyPI <https://pypi.python.org/pypi/drms>`_ 
@@ -19,7 +19,7 @@ AIA and MDI data with Python. It uses the publicly accessible
 `JSOC <http://jsoc.stanford.edu/>`_ DRMS server by default, but can also
 be used with local `NetDRMS <http://jsoc.stanford.edu/netdrms/>`_ sites.
 More information, including a detailed tutorial, is available in the
-`Documentation <https://docs.sunpy.org/projects/drms>`_.
+`Documentation <https://docs.sunpy.org/projects/drms/>`_.
 
 
 Requirements


### PR DESCRIPTION
The first two links to the documentation in the README don't work.  Apparently a trailing slash is critical.