### PR TITLE
added appropriate error for missing email

### DIFF
--- a/drms/client.py
+++ b/drms/client.py
@@ -848,6 +848,8 @@ class Client:
     @email.setter
     def email(self, value):
         if value is not None and not self.check_email(value):
+            if len(value) == 0:
+                raise ValueError('Email address is not specified by a.jsoc.Notify')
             raise ValueError('Email address is invalid or not registered')
         self._email = value
 


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Addresses https://github.com/sunpy/sunpy/issues/4923. As mentioned in https://github.com/sunpy/sunpy/issues/4923#issuecomment-771142258, ```fido.search``` without passing ```a.jsoc.Notify``` causes the drms client to check for an email of length = 0. This addresses this issue by raising a separate error if the length of the email is = 0.
