### PR TITLE
Row-centric hex string handling

### DIFF
--- a/changelog/102.bugfix.rst
+++ b/changelog/102.bugfix.rst
@@ -1,1 +1,1 @@
-Modified :func:`drms.client._convert_numeric_keywords` to use a row-centric approach for handling hexadecimal strings.
+Modified :meth:`drms.client.Client._convert_numeric_keywords` to use a row-centric approach for handling hexadecimal strings.

--- a/changelog/102.bugfix.rst
+++ b/changelog/102.bugfix.rst
@@ -1,0 +1,1 @@
+Modified :func:`drms.client._convert_numeric_keywords` to use a row-centric approach for handling hexadecimal strings.

--- a/drms/client.py
+++ b/drms/client.py
@@ -651,7 +651,7 @@ class Client:
                 idx = kdf[k].str.startswith("0x")
                 if idx.any():
                     k_idx = kdf.columns.get_loc(k)
-                    kdf[kdf.columns[k_idx]] = kdf[kdf.columns[k_idx]].apply(int, base=16)
+                    kdf.loc[idx, kdf.columns[k_idx]] = kdf.loc[idx, kdf.columns[k_idx]].apply(int, base=16)
             if k in num_keys:
                 kdf[k] = _pd_to_numeric_coerce(kdf[k])
 

--- a/drms/tests/test_jsoc_query.py
+++ b/drms/tests/test_jsoc_query.py
@@ -95,7 +95,10 @@ def test_query_invalid_series(jsoc_client):
 
 
 @pytest.mark.remote_data
-def test_query_hexadecimal_strings():
+@pytest.mark.parametrize(
+    "query", ["hmi.v_45s[2014.01.01_00:00:35_TAI-2014.01.01_01:00:35_TAI]", "hmi.M_720s[2011.04.14_00:30:00_TAI/6h@2h]"]
+)
+def test_query_hexadecimal_strings(query):
     # Exercise the part of client.py that deals with hexadecimal strings
     c = drms.Client()
-    c.query("hmi.v_45s[2014.01.01_00:00:35_TAI-2014.01.01_01:00:35_TAI]", key="**ALL**")
+    c.query(query, key="**ALL**")


### PR DESCRIPTION
This PR modifies the handling of hexadecimal strings within `drms/client.py` to convert select rows to base 16 integers, rather than converting all entries within a column.

Closes https://github.com/sunpy/drms/issues/98

The following test was added to cover the changes

```python
import drms
client = drms.Client(debug=True, verbose=True, email="pjwright@stanford.edu")
keys = client.query('hmi.M_720s[2011.04.14_00:30:00_TAI/6h@2h]', key=drms.const.all)
```

```shell
                   DATE                DATE__OBS                 DATE-OBS  ...                                           CODEVER2                                           CODEVER3  CALVER64
0  2011-04-19T00:30:15Z                  MISSING                  MISSING  ...                                            MISSING                                            MISSING         0
1  2011-04-19T00:30:17Z                  MISSING                  MISSING  ...                                            MISSING                                            MISSING         0
2  2012-09-05T08:54:25Z  2011-04-14T04:34:20.00Z  2011-04-14T04:34:20.00Z  ...  $Id: interpol_code.c,v 1.1 2010/09/16 20:46:48...  $Id: polcal.c,v 1.4 2010/09/23 20:57:27 schou ...        16

[3 rows x 87 columns]
```